### PR TITLE
Add lingreg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# MacOS
+*.DS_Store

--- a/src/lingrex/regularity.py
+++ b/src/lingrex/regularity.py
@@ -1,0 +1,82 @@
+"""
+Calculate regularity metrics on dataset.
+"""
+import statistics
+
+
+def regularity(wordlist, threshold=3, ref="cogid", min_refs=3, word_threshold=0.75):
+    """
+    Check regularity in three flavors.
+
+    - regularity based on the number of correspondence patterns that have more
+      or the same number of sites as threshold
+    - the proportion of correspondence patterns identified as regular via
+      threshold counting all alignment sites
+    - the proportion of words that we judge regular, judging words to be
+      regular when more than the proportion word_threshold of sites are judged
+      to be regular since they can be assigned to patterns that are covered by
+      more than threshol sites
+
+    :param wordlist: A lingpy Wordlist.
+    :type wordlist: :class:lingpy.Wordlist
+    :param threshold: The minimum number of alignment sites for a cognate set
+        to be considered in the computation of regular words. Defaults to '3'.
+    :type threshold: int
+    :param ref: The column which stores the cognate sets, defaults to 'cogid'
+    :type ref: str
+    :param min_refs: The minimum number of occurrences a correspondence pattern
+        to be considered recurring. Defaults to '3'.
+    :type min_refs: int
+    :param word_threshold: The relative threshold of patterns that need to be regular
+        in order for a word to be considered regular as well. Defaults to '0.75'.
+    :type word_threshold: int
+    :return: Different scores of regularity.
+    :rtype: tuple
+    """
+    if not hasattr(wordlist, "clusters"):
+        raise ValueError("need a CoPaR object with clusters")
+    patterns = len({
+            p: len(vals) for p, vals in wordlist.clusters.items()
+            })
+    regular_patterns = len([p for p, vals in wordlist.clusters.items() if
+                            len(vals) >= threshold])
+    regular_proportion = sum([len(vals) for vals in wordlist.clusters.values()
+                              if len(vals) >= threshold])
+    full_proportion = sum([len(vals) for vals in wordlist.clusters.values()])
+
+    # get the proportion of words
+    regular_words, irregular_words = 0, 0
+    for cogid, msa in filter(
+            lambda x: len(set(x[1]["taxa"])) >= min_refs, 
+            wordlist.msa[ref].items()):
+        scores = []
+        for idx in range(len(msa["alignment"][0])):
+            if (cogid, idx) not in wordlist.patterns:
+                print("warning, duplicate cognate in {0} / {1}".format(
+                    cogid, idx))
+            else:
+                if max([
+                        len(wordlist.clusters[b, c]) for a, b, c in
+                        wordlist.patterns[cogid, idx]]) >= threshold:
+                    scores += [1]
+                else:
+                    scores += [0]
+        if statistics.mean(scores) >= word_threshold:
+            regular_words += len(set(msa["taxa"]))
+        else:
+            irregular_words += len(set(msa["taxa"]))
+
+    return (
+        regular_patterns,
+        patterns - regular_patterns,
+        patterns,
+        round((regular_patterns / patterns), 2),
+        regular_proportion, 
+        full_proportion - regular_proportion,
+        full_proportion,
+        round((regular_proportion / full_proportion),2),
+        regular_words,
+        irregular_words,
+        regular_words + irregular_words,
+        round((regular_words / (regular_words + irregular_words)),2)
+        )

--- a/src/lingrex/trimming.py
+++ b/src/lingrex/trimming.py
@@ -1,0 +1,201 @@
+"""
+Trimming functionalities in lingrex.
+"""
+import random
+import collections
+from lingpy.sequence.sound_classes import token2class
+
+
+def revert(alms):
+    return [[row[i] for row in alms] for i in range(len(alms[0]))]        
+
+
+def get_skeleton(alms, gap="-"):
+    return [token2class(([c for c in col if c != gap] or ["+"])[0], "cv") for col in revert(alms)]
+
+
+def apply_trim(alms, idxs):
+    """
+    Basic trimming function, based on a selection of indices that are trimmed.
+    """
+    return [[row[i] for i in range(len(row)) if i not in idxs] for row in alms]
+
+
+def subsequence_of(source, target):
+    """
+    Check if source is a subsequence of target.
+    """
+    q_1, q_2 = list(target), list(source)
+    while q_1:
+        s = q_1.pop(0)
+        if q_2 and q_2[0] == s:
+            q_2.pop(0)
+        elif q_2:
+            pass
+        else:
+            break
+    if not q_2:
+        return True
+    return False
+
+
+def consecutive_gaps(seq, gap="-"):
+    """
+    Return consecutive gaps in line.
+    """
+    start, end = [0], [len(seq)]
+    for i in range(len(seq)):
+        if seq[i] == gap:
+            gapped = True
+        else:
+            gapped = False
+        if gapped:
+            start += [i + 1]
+        if not gapped:
+            break
+    for i in range(len(seq) - 1, 0, -1):
+        if seq[i] == "-":
+            gapped = True
+        else:
+            gapped = False
+        if gapped:
+            end += [i]
+        if not gapped:
+            break
+    return start[:-1], end[::-1][:-1]
+
+
+def gap_profile(alms, gap="-"):
+    """
+    Return a profile of the gap-ration per column.
+    """
+    return [col.count(gap) / len(col) for col in revert(alms)]
+
+
+def trim_by_gap(alms, threshold=0.5, skeletons=("CV", "VC"), gap="-", exclude="_+"):
+    """
+    Trim alignment sites by gaps.
+
+    :parameter alms: Alignment sites of a cognate set.
+    :type alms: list
+    :parameter threshold: Threshold by which sites with gaps should be trimmed.
+        Defaults to '0.5'.
+    :type threshold: int
+    :param skeletons: Tuple of syllable-skeletons that should be preserved
+        for further processing. Defaults to '("CV", "VC")'.
+    :type skeletons: tuple
+    :parameter gap: String that codes gaps in alignment sites. Defaults to '-'.
+    :type gap: string
+    :param exclude: Sequence of strings that should be excluded from further processing,
+        e.g. morpheme boundaries. Defaults to '_+'.
+    :param exclude: str
+    :return: Indices of trimmed strings.
+    :rtype: set
+    """
+    skeleton = get_skeleton(alms, gap=gap)
+    profile = gap_profile(alms, gap)
+    # exclude markers
+    idxs = [i for i, c in enumerate(skeleton) if c in exclude]
+    # order by gap weights
+    sorted_profile = sorted(enumerate(profile), key=lambda x: x[1], reverse=True)
+    while sorted_profile:
+        idx, score = sorted_profile.pop(0)
+        if score >= threshold:
+            current_skeleton = "".join([skeleton[i] for i in
+                                        range(len(skeleton)) if i not in idxs+[idx]])
+            if any([subsequence_of(s, current_skeleton) for s in skeletons]):
+                idxs += [idx]
+            else:
+                break
+        else:
+            break
+    return sorted(set(idxs))
+
+
+def trim_by_core(
+        alms, threshold=0.5, skeletons=("CV", "VC"), gap="-",
+        exclude="_+"
+        ):
+    """
+    Trim alignment sites by gaps, preserving a core of sites.
+
+    :parameter alms: Alignment sites of a cognate set.
+    :type alms: list
+    :parameter threshold: Threshold by which sites with gaps should be trimmed.
+        Defaults to '0.5'.
+    :type threshold: int
+    :param skeletons: Tuple of syllable-skeletons that should be preserved
+        for further processing. Defaults to '("CV", "VC")'.
+    :type skeletons: tuple
+    :parameter gap: String that codes gaps in alignment sites. Defaults to '-'.
+    :type gap: string
+    :return: Indices of trimmed strings.
+    :rtype: set
+    """
+    cons = [gap if c >= threshold else "S" for c in gap_profile(alms, gap=gap)]
+    skeleton = get_skeleton(alms, gap=gap)
+    left, right = consecutive_gaps(cons)
+
+    idxs = [i for i, c in enumerate(skeleton) if c in exclude]
+
+    # order by first
+    sorted_indices = right[::-1] + left
+    while sorted_indices:
+        idx = sorted_indices.pop(0)
+        current_skeleton = "".join([skeleton[i] for i in
+                                    range(len(skeleton)) if i not in idxs+[idx]])
+        if any([subsequence_of(s, current_skeleton) for s in skeletons]):
+            idxs += [idx]
+        else:
+            break
+    return sorted(set(idxs))
+
+
+def trim_random(
+        alms,
+        func=None,
+        threshold=0.5,
+        skeletons=("CV", "VC"),
+        gap="-",
+        exclude="_+",
+        ):
+    """
+    For a base trim function, return a random version with a similar CV distribution.
+
+    :parameter alms: Alignment sites of a cognate set.
+    :type alms: list
+    :parameter func: Trimming function that should be applied. Defaults to 'None'.
+    :type func: function
+    :parameter threshold: Threshold by which sites with gaps should be trimmed.
+        Defaults to '0.5'.
+    :type threshold: int
+    :param skeletons: Tuple of syllable-skeletons that should be preserved
+        for further processing. Defaults to '("CV", "VC")'.
+    :type skeletons: tuple
+    :parameter gap: String that codes gaps in alignment sites. Defaults to '-'.
+    :type gap: string
+    :return: Indices of trimmed strings.
+    :rtype: set
+    """
+    func = func or trim_by_gap
+    reference = apply_trim(
+            alms,
+            func(
+                alms, threshold=threshold, skeletons=skeletons, gap=gap,
+                exclude=exclude)
+            )
+    reference_skeleton = get_skeleton(reference)
+    # create a freq dict of ref skel
+    rs_freqs = collections.defaultdict(int)
+    for c in reference_skeleton:
+        rs_freqs[c] += 1
+    # get a dictionary of indices by position
+    indices = collections.defaultdict(list)
+    for i, c in enumerate(get_skeleton(alms)):
+        indices[c] += [i]
+    # random sample indices to be retained
+    retain = []
+    for c, _ in rs_freqs.items():
+        retain += random.sample(indices[c], rs_freqs[c])
+    to_trim = [i for i in range(len(alms[0])) if i not in retain]
+    return to_trim

--- a/tests/test_regularity.py
+++ b/tests/test_regularity.py
@@ -1,0 +1,33 @@
+from pytest import raises
+from lingpy import Wordlist, Alignments
+from lingrex.copar import CoPaR
+from lingrex.util import add_structure
+from lingrex.regularity import regularity
+
+
+dummy_wl = {
+    0: ["doculect", "concept", "form", "ipa", "alignment", "cogid"],
+    1: ["A", "one", "atawu", "atawu", "a t a w u", 1],
+    2: ["B", "one", "atwu", "atwu", "a t - w u", 1],
+    3: ["C", "one", "tawu", "tawu", "- t a w u", 1],
+    4: ["D", "one", "tefu", "tefu", "- t e f u", 1],
+    5: ["A", "two", "satu", "satu", "s a t u", 2],
+    6: ["B", "two", "setu", "setu", "s e t u", 2],
+    7: ["C", "two", "situ", "situ", "s i t u", 2]
+}
+
+
+def test_regularity():
+    test_wl = Wordlist(dummy_wl)
+    with raises(ValueError):
+        regularity(test_wl)
+
+    test_alg = Alignments(test_wl)
+    add_structure(test_alg, model="cv", structure="structure")
+    test_alg = CoPaR(test_alg, ref="cogid")
+    test_alg.get_sites()
+    test_alg.cluster_sites()
+    test_alg.sites_to_pattern()
+    output = regularity(test_alg, threshold=2, word_threshold=0.5)
+
+    assert output == (2, 5, 7, 0.29, 4, 5, 9, 0.44, 3, 4, 7, 0.43)

--- a/tests/test_trimming.py
+++ b/tests/test_trimming.py
@@ -1,0 +1,61 @@
+from lingrex.trimming import (
+        apply_trim, revert, get_skeleton, consecutive_gaps, gap_profile,
+        trim_by_gap,trim_by_core, trim_random, subsequence_of
+        )
+import random
+random.seed(1234)
+
+
+def test_gap_profile():
+    assert gap_profile(["aaa", "aaa"], gap="-") == [0.0, 0.0, 0.0]
+    assert gap_profile(["aa", "a-"], gap="-") == [0.0, 0.5]
+
+def test_apply_trim():
+
+    alm = [
+            list("toxta-"), list("to-tir"), 
+            list("to-t-r"), list("do--ar")]
+    trimmed = apply_trim(alm, [2, 5])
+    assert " ".join(trimmed[0]) == "t o t a" 
+
+
+def test_get_skeleton():
+    assert get_skeleton(["-bc", "ab-"], gap="-") == ["V", "C", "C"]
+
+
+def test_revert():
+    assert revert(["ab", "ab"]) == [["a", "a"], ["b", "b"]]
+
+
+def test_trim_by_gap():
+    assert trim_by_gap(["abc", "a-c", "--c"]) == [1]
+    assert trim_by_gap(["a+bco", "-+cco", "-+cco"], exclude="_+") == [0, 1]
+    assert trim_by_gap(["a+b", "-+c", "-+c"], exclude="") == []
+
+
+def test_subsequence_of():
+    assert subsequence_of("cvc", "cvcvc")
+    assert subsequence_of("bla", "bla")
+    assert not subsequence_of("abc", "ab")
+
+
+def test_consecutive_gaps():
+    left, right = consecutive_gaps("--mat-gu-go--", gap="-")
+    assert " ".join([c for i, c in enumerate("--mat-gu-go--") if i not in
+                     left+right]
+                    ) == "m a t - g u - g o"
+
+
+def test_trim_by_core():
+    assert trim_by_core(["--mat", "-xmut", "--mit", "m-xit"]) == [0, 1]
+    assert trim_by_core(["--mat--", "-xmut--", "--mitx-", "m-xit-x"]) == [0, 1, 5, 6]
+
+
+
+def test_trim_random():
+    
+    alms = ["--mat", "-xmut", "m-xut", "--xit"]
+    assert len(trim_by_gap(alms)) == len(trim_random(alms))
+    assert set(get_skeleton(apply_trim(alms, trim_by_gap(alms)))) == \
+            set(get_skeleton(apply_trim(alms, trim_random(alms))))
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,8 @@
 import pytest
-from lingrex.util import lingrex_path, add_structure
 from lingpy import Wordlist, Alignments
+from lingrex.util import lingrex_path, add_structure
 from lingrex.util import ungap, clean_sound, unjoin, alm2tok, bleu_score
+from lingrex.util import prep_wordlist, prep_alignments        
 
 
 def test_bleu_score():
@@ -95,3 +96,32 @@ def test_add_structure():
         }
         wl = Alignments(D, ref="cogids", transcription="tokens")
         add_structure(wl, m, ref="cogids")
+
+
+dummy_wl = {
+    0: ["doculect", "concept", "form", "tokens", "alignment", "cogid"],
+    1: ["A", "one", "atawu", "ata+wu", "a t a w u", 1],
+    2: ["B", "one", "a_twu", "a_twu", "a t - w u", 1],
+    3: ["C", "one", "tawu", "tawu", "- t a w u", 1],
+    4: ["D", "one", "tefu", "tefu", "- t e f u", 1],
+    5: ["A", "two", "satu", "satu", "s a t u", 2],
+    6: ["A", "two", "seram", "seram", "s e r a m", 2]
+}
+
+
+def test_prep_wordlist():
+    test_wl = Wordlist(dummy_wl)
+    test_wl = prep_wordlist(test_wl)
+
+    assert len(test_wl) == 4
+    assert "+" not in test_wl[1, "tokens"]
+    assert "_" not in test_wl[2, "tokens"]
+
+
+def test_prep_alignments():
+    test_wl = Wordlist(dummy_wl)
+    test_wl = prep_wordlist(test_wl)
+    test_wl = Alignments(test_wl, transcription="form")
+    test_wl = prep_alignments(test_wl)
+
+    assert test_wl[4, "structure"] == "C V C V"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -119,9 +119,7 @@ def test_prep_wordlist():
 
 
 def test_prep_alignments():
-    test_wl = Wordlist(dummy_wl)
-    test_wl = prep_wordlist(test_wl)
-    test_wl = Alignments(test_wl, transcription="form")
+    test_wl = Alignments(dummy_wl, transcription="form")
     test_wl = prep_alignments(test_wl)
 
     assert test_wl[4, "structure"] == "C V C V"


### PR DESCRIPTION
This PR adds the functions from the trimming-paper (SIGTYP '23) to lingrex. It adds two new modules (regularity, trimming), and adds some further utility functions to util. It also adds the necessary tests.

I have a couple of short questions:

- Are the tests overly complex as they are, i.e. should I rather spell out a CoPaR item literally instead of running through the conversion of an artificial wordlist like I currently do for [test_regularity](https://github.com/lingpy/lingrex/blob/lingreg/tests/test_regularity.py)
- Two statements are currently not part of the tests as I do not know how to test for them. These are a warning statement, and a breaking loop. Other such cases are also present in the other modules, so I am not sure if these need to be added?
- I have not added a detailed description of the smaller functions in [trimming.py](https://github.com/lingpy/lingrex/blob/lingreg/src/lingrex/trimming.py). Should these be added or can we skip them? I have added them for the major functions that get called by the user.

This PR partially resolves #36 .

Is there anything else that needs to be resolved @LinguList ?